### PR TITLE
Cell replacement for --arrange, --flip and --obfuscate

### DIFF
--- a/mocodo/argument_parser.py
+++ b/mocodo/argument_parser.py
@@ -193,6 +193,7 @@ def parsed_arguments():
     source_group.add_argument("--obfuscate", metavar="PATH", type=os.path.abspath, nargs="?", const="lorem_ipsum.txt", help="display an obfuscated version of the input file, then exit. Cf. directory 'lorem'")
     source_group.add_argument("--obfuscation_max_length", metavar="INT", type=int, help="maximal length of obfuscated labels")
     source_group.add_argument("--seed", metavar="FLOAT", type=float, help="initial value for the random number generator")
+    source_group.add_argument("--replace", action="store_true", help="replace the content of the current cell by the output of the for the rearrangement option")
 
     bb_group.add_argument("--call_limit", metavar="INT", type=int, default=10000, help="maximal number of calls for a given starting box")
     bb_group.add_argument("--min_objective", metavar="INT", type=int, default=0, help="best acceptable fitness for a layout")

--- a/nb_magic/mocodo.py
+++ b/nb_magic/mocodo.py
@@ -85,8 +85,11 @@ class MocodoMagics(Magics):
                 elif "--help" in options:
                     print stdoutdata
                 else:
-                    print "%%mocodo"
-                    print stdoutdata
+                    if "--replace" in options:
+                        get_ipython().set_next_input("%%mocodo\n"+stdoutdata, replace = True)
+                    else:
+                        print "%%mocodo"
+                        print stdoutdata
                     if not notebook_options.no_mcd or notebook_options.mld:
                         parser.add_argument("--arrange", nargs="?")
                         parser.add_argument("--obfuscate", nargs="?")


### PR DESCRIPTION
`--arrange`, `--flip` and `--obfuscate` currently generates a new mocodo as output

With this update when `--replace` is passed as option, the rearrangement replace the content of the cell