### PR TITLE
Un dernier hommage…

### DIFF
--- a/mocodo/relations.py
+++ b/mocodo/relations.py
@@ -65,7 +65,7 @@ class Relations:
         self.add_sorting_this_relation_number()
         self.may_disambiguate_with_leg_annotations = set_disambiguation_strategy(params["disambiguation"])
         may_update_params_with_guessed_title()
-        
+
     
     def get_text(self, template):
         
@@ -254,12 +254,12 @@ class Relations:
                             continue
                         if not other_entity.is_strong_or_strengthened:
                             break # weak entity linked to a weak entity
-                        strengthening_entities.append(other_entity)
+                        strengthening_entities.append((other_entity, association))
                     else:
                         continue
                     break
                 if strengthening_entities:
-                    for strengthening_entity in strengthening_entities:
+                    for strengthening_entity, association in strengthening_entities:
                         # find the potential annotation on the strenghening leg
                         for leg in association.legs:
                             if leg.entity_name == strengthening_entity.name:


### PR DESCRIPTION
J'aimerai rendre un dernier hommage à Mocodo avant que l'on se quitte définitivement. 
Ce merveilleux logiciel que j'ai utilisé la dernière fois le vendredi 17 décembre 2016 à 14h30,
~~est bourré de bugs~~ mérite une contribution, aussi modeste soit-elle.

Cette pull request résout le bug #29. La liste des attributs renforçants contient toujours la même association pour chaque élément, donc certains ont la mauvaise association et sont dupliqués dans `process_associations`.

Et bien évidemment, Joyeux Noël !


Oui nous ne sommes que le 18 décembre:
![aristhug_small](https://cloud.githubusercontent.com/assets/4079818/21292958/517763f6-c516-11e6-8089-d8f846e4f7bc.jpg)

