### PR TITLE
fix a regression of 62b5998 for multiple args

### DIFF
--- a/index.php
+++ b/index.php
@@ -113,7 +113,7 @@ if ($lib) {
 								<span class="popup-item popup-close" onclick="closePopup()">⨉</span>
 								<span class="popup-item" onclick="rewrite('drown')">masquer avec des libellés génériques numérotés</span>
 								<span class="popup-item" onclick="rewrite('delete')" title="Crée un MCD à compléter. À accompagner de la liste des descriptifs des attributs obtenue avec l'option « Dictionnaire des données en Markdown (deux colonnes) ».">masquer les attributs et les cardinalités</span>
-								<span class="popup-item" onclick="rewrite('create:types=PLACEHOLDER randomize:types')">remplir les types au hasard</span>
+								<span class="popup-item" onclick="rewrite('create:types=PLACEHOLDER randomize:types')">remplir les types au hasard</span> <!-- Create the types as an arbitrary NONEMPTY string, then randomize them. -->
 								<span class="popup-item" onclick="rewrite('grow:n=9,from_scratch,ent_attrs=3 obfuscate:labels=en4 create:roles lower:roles arrange')">créer un MCD d'entraînement à la conversion en relationnel</span>
 								<span class="popup-item" onclick="rewrite('grow:from_scratch,arity_3=1 arrange')">créer un MCD aléatoire avec des libellés génériques numérotés</span>
 								<span class="popup-item" onclick="rewrite('obfuscate')">masquer avec du faux texte (double clic)</span>

--- a/web/rewrite.php
+++ b/web/rewrite.php
@@ -42,7 +42,7 @@ if (strpos($_SERVER['HTTP_REFERER'], 'localhost')) {
   } else {
     $mocodo = "~/.local/bin/mocodo";
 };
-$command_line = "{$mocodo} -t " . escapeshellarg($_POST['args']) . " 2>&1"; //
+$command_line = "{$mocodo} -t " . escapeshellcmd($_POST['args']) . " 2>&1";
 
 // Execute the command and test the exit code.
 // If it is not 0, return an array with a key "err" and the error message.


### PR DESCRIPTION
`escapeshellarg` was transforming a sequence of rewritings such as:

```
mocodo -t create:types=PLACEHOLDER randomize:types
```

into:

```
mocodo -t "create:types=PLACEHOLDER randomize:types"
```

`escapeshellcmd` seems to do the trick.